### PR TITLE
feat: add lazy loading to images and use image optimizations

### DIFF
--- a/src/components/ui/project/irysmanga/IrysMangaSubmissionWrapper.tsx
+++ b/src/components/ui/project/irysmanga/IrysMangaSubmissionWrapper.tsx
@@ -3,6 +3,8 @@ import { Language } from '@/lib/i18n/languages';
 import { Jura } from 'next/font/google';
 import { MangaProvider } from './context/MangaContext';
 import IrysManga from './IrysManga';
+import getManga from './utils/data-helper';
+import { getImageUrl } from '../../old/Image';
 
 interface IProps {
 	project: Omit<Project, 'flags' | 'devprops'> & {
@@ -19,10 +21,36 @@ const jura = Jura({
 	subsets: ['latin'],
 });
 
-export default function IrysMangaSubmissionWrapper({ project, lang }: IProps) {
+async function fetchOptimizedImageURLs({ project, lang }: IProps) {
+	// TODO: Change this to serve the actual manga.
+	const manga = getManga(project.devprops);
+	const { chapters } = manga.data[lang];
+
+	const optimizedImages = new Map<string, string[]>();
+
+	chapters.forEach((chapter) => {
+		optimizedImages.set(
+			chapter.title,
+			chapter.pages.map((page) => getImageUrl(
+				{
+					src: page,
+					height: 1080,
+					quality: 90,
+					action: 'resize',
+				},
+			)),
+		);
+	});
+
+	return optimizedImages;
+}
+
+export default async function IrysMangaSubmissionWrapper({ project, lang }: IProps) {
+	const optimizedImages = await fetchOptimizedImageURLs({ project, lang });
+
 	return (
 		<div className={jura.className}>
-			<MangaProvider devProps={project.devprops} lang={lang}>
+			<MangaProvider devProps={project.devprops} lang={lang} optimizedImages={optimizedImages}>
 				<IrysManga />
 			</MangaProvider>
 		</div>

--- a/src/components/ui/project/irysmanga/IrysMangaSubmissionWrapper.tsx
+++ b/src/components/ui/project/irysmanga/IrysMangaSubmissionWrapper.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Project } from '@/types/payload-types';
 import { Language } from '@/lib/i18n/languages';
 import { Jura } from 'next/font/google';

--- a/src/components/ui/project/irysmanga/Reader.tsx
+++ b/src/components/ui/project/irysmanga/Reader.tsx
@@ -77,6 +77,14 @@ function Reader({
 		}
 	};
 
+	/**
+	 * Check whether we should preload an image for a page.
+	 * Note we preload a few pages in advance (or behind just in case you try jumping pages)
+	 * for a better reading experience, but we don't want to load all the images at once
+	 * because that might be slow.
+	*/
+	const shouldPreload = (numPages: number, pg: number): ('eager' | 'lazy') => (Math.abs(numPages - pg) > 3 ? 'lazy' : 'eager');
+
 	// Handle page turn on click
 	const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
 		const { clientX, target } = event;
@@ -168,6 +176,7 @@ function Reader({
                         [styles.pageWidth]: fitMode === "width",
                     })}
                     alt={`Page ${i + 1}`}
+					loading={shouldPreload(i, page)}
                 />
             ));
         } else {
@@ -182,6 +191,7 @@ function Reader({
                         [styles.pageWidth]: fitMode === "width",
                     })}
                     alt={`Page ${i + 1}`}
+					loading={shouldPreload(i, page)} // Preload up to 3 pages in advance.
                 />
             ));
         }

--- a/src/components/ui/project/irysmanga/Reader.tsx
+++ b/src/components/ui/project/irysmanga/Reader.tsx
@@ -32,6 +32,7 @@ function Reader({
 		manga,
 		direction,
 		mangaLanguage,
+		optimizedImages,
 	} = useMangaContext();
 
 	// const containerRef = useRef<HTMLDivElement>(null);
@@ -162,7 +163,8 @@ function Reader({
 	if (mangaData.chapters[chapter]) {
 		const currentChapter = mangaData.chapters[chapter];
 		const maxPageCount = currentChapter.pageCount;
-		const currentPages = currentChapter.pages;
+		// Use optimized pages if we have them, otherwise fall back to unoptimized I guess.
+		const currentPages = optimizedImages.get(currentChapter.title) ?? currentChapter.pages;
 
 		const getClassNames = (i: number) => {
 			const blockStyle = pageLayout === 'single' ? {

--- a/src/components/ui/project/irysmanga/Reader.tsx
+++ b/src/components/ui/project/irysmanga/Reader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import classNames from 'classnames';
 import React, { useEffect, useRef } from 'react';
 import { useMangaContext } from './context/MangaContext';
@@ -44,8 +46,8 @@ function Reader({
 			const targetImg = pageRefs.current[page];
 			if (targetImg) {
 				// eslint-disable-next-line
-                containerRef.current.scrollTop =
-                    targetImg.offsetTop - containerRef.current.offsetTop;
+				containerRef.current.scrollTop =
+					targetImg.offsetTop - containerRef.current.offsetTop;
 			}
 		}
 	};
@@ -146,12 +148,12 @@ function Reader({
 	};
 
 	// eslint-disable-next-line
-    useEffect(() => {
+	useEffect(() => {
 		handleScrollTop();
 	}, [page, chapter, pageLayout]);
 
 	// eslint-disable-next-line
-    useEffect(() => {
+	useEffect(() => {
 		setScollTopToPage();
 	}, [fitMode]);
 
@@ -162,62 +164,55 @@ function Reader({
 		const maxPageCount = currentChapter.pageCount;
 		const currentPages = currentChapter.pages;
 
-		/* eslint-disable */
-        if (pageLayout === "single") {
-            displayedPages = Array.from({ length: maxPageCount }, (_, i) => (
-                <img
-                    key={i}
-                    ref={(el) => (pageRefs.current[i] = el as HTMLImageElement)}
-                    src={currentPages[i]}
-                    className={classNames(styles.page, {
-                        block: i === page,
-                        hidden: i !== page,
-                        [styles.pageHeight]: fitMode === "height",
-                        [styles.pageWidth]: fitMode === "width",
-                    })}
-                    alt={`Page ${i + 1}`}
-					loading={shouldPreload(i, page)}
-                />
-            ));
-        } else {
-            displayedPages = Array.from({ length: maxPageCount }, (_, i) => (
-                <img
-                    key={i}
-                    ref={(el) => (pageRefs.current[i] = el as HTMLImageElement)}
-                    src={currentPages[i]}
-                    className={classNames(styles.page, {
-                        block: true,
-                        [styles.pageHeight]: fitMode === "height",
-                        [styles.pageWidth]: fitMode === "width",
-                    })}
-                    alt={`Page ${i + 1}`}
-					loading={shouldPreload(i, page)} // Preload up to 3 pages in advance.
-                />
-            ));
-        }
+		const getClassNames = (i: number) => {
+			const blockStyle = pageLayout === 'single' ? {
+				block: i === page,
+				hidden: i !== page,
+			} : {
+				block: true,
+			};
 
-        // eslint-enable
-    }
+			return classNames(
+				styles.page,
+				blockStyle,
+				{
+					[styles.pageHeight]: fitMode === 'height',
+					[styles.pageWidth]: fitMode === 'width',
+				},
+			);
+		};
 
-    /* eslint-disable */
-    return (
-        <div className="flex flex-col h-screen relative grow bg-base-100 transition-colors">
-            <ReaderHeader setOpenSidebar={setOpenSidebar}></ReaderHeader>
-            <div
-                ref={containerRef}
-                className={styles.pageContainer}
-                onClick={handleClick}
-                onScroll={handleScroll}
-                tabIndex={0}
-            >
-                {displayedPages}
-            </div>
-            <div className="absolute bottom-0 left-0 w-full">
-                <ProgressBar></ProgressBar>
-            </div>
-        </div>
-    );
-    // eslint-enable
+		displayedPages = Array.from({ length: maxPageCount }, (_, i) => (
+			<img
+				key={i}
+				ref={(el) => { pageRefs.current[i] = el as HTMLImageElement; }}
+				src={currentPages[i]}
+				className={getClassNames(i)}
+				alt={`Page ${i + 1}`}
+				loading={shouldPreload(i, page)}
+			/>
+		));
+	}
+
+	/* eslint-disable */
+	return (
+		<div className="flex flex-col h-screen relative grow bg-base-100 transition-colors">
+			<ReaderHeader setOpenSidebar={setOpenSidebar}></ReaderHeader>
+			<div
+				ref={containerRef}
+				className={styles.pageContainer}
+				onClick={handleClick}
+				onScroll={handleScroll}
+				tabIndex={0}
+			>
+				{displayedPages}
+			</div>
+			<div className="absolute bottom-0 left-0 w-full">
+				<ProgressBar></ProgressBar>
+			</div>
+		</div>
+	);
+	// eslint-enable
 }
 
 export default Reader;

--- a/src/components/ui/project/irysmanga/context/MangaContext.tsx
+++ b/src/components/ui/project/irysmanga/context/MangaContext.tsx
@@ -50,6 +50,8 @@ interface MangaContextProps {
 
 	manga: Manga;
 	setManga: React.Dispatch<React.SetStateAction<Manga>>;
+
+	optimizedImages: Map<string, string[]>
 }
 
 // Creating a context object
@@ -57,8 +59,8 @@ const MangaContext = createContext<MangaContextProps | undefined>(undefined);
 
 /* eslint-disable */
 // Creating a provider component
-export const MangaProvider: React.FC<{ children: React.ReactNode, devProps: { [key: string]: string }, lang: Language }> = (
-	{ children, devProps, lang }) => {
+export const MangaProvider: React.FC<{ children: React.ReactNode, devProps: { [key: string]: string }, lang: Language, optimizedImages: Map<string, string[]> }> = (
+	{ children, devProps, lang, optimizedImages }) => {
 	const [readerLanguage, setReaderLanguage] = useState<Language>(lang);
 	const [mangaLanguage, setMangaLanguage] = useState<Language>(lang);
 	const [pageLayout, setPageLayout] = useState<PageLayout>("single");
@@ -99,6 +101,7 @@ export const MangaProvider: React.FC<{ children: React.ReactNode, devProps: { [k
 			setReaderTheme,
 			manga,
 			setManga,
+			optimizedImages,
 		}),
 		[
 			readerLanguage,
@@ -112,6 +115,7 @@ export const MangaProvider: React.FC<{ children: React.ReactNode, devProps: { [k
 			progressVisibility,
 			readerTheme,
 			manga,
+			optimizedImages,
 		]
 	);
 

--- a/src/components/ui/project/irysmanga/context/MangaContext.tsx
+++ b/src/components/ui/project/irysmanga/context/MangaContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
 	createContext, useState, useContext, useMemo,
 } from 'react';
@@ -24,6 +26,7 @@ interface MangaContextProps {
 
 	page: number;
 	setPage: React.Dispatch<React.SetStateAction<number>>;
+
 	chapter: number;
 	setChapter: React.Dispatch<React.SetStateAction<number>>;
 
@@ -40,12 +43,11 @@ interface MangaContextProps {
 	setHeaderVisibility: React.Dispatch<React.SetStateAction<HeaderVisibility>>;
 
 	progressVisibility: ProgressVisibility;
-	setProgressVisibility: React.Dispatch<
-	React.SetStateAction<ProgressVisibility>
-	>;
+	setProgressVisibility: React.Dispatch<React.SetStateAction<ProgressVisibility>>;
 
 	readerTheme: ReaderTheme;
 	setReaderTheme: React.Dispatch<React.SetStateAction<ReaderTheme>>;
+
 	manga: Manga;
 	setManga: React.Dispatch<React.SetStateAction<Manga>>;
 }
@@ -56,78 +58,76 @@ const MangaContext = createContext<MangaContextProps | undefined>(undefined);
 /* eslint-disable */
 // Creating a provider component
 export const MangaProvider: React.FC<{ children: React.ReactNode, devProps: { [key: string]: string }, lang: Language }> = (
-    { children, devProps, lang }) => {
-    const [readerLanguage, setReaderLanguage] = useState<Language>(lang);
-    const [mangaLanguage, setMangaLanguage] = useState<Language>(lang);
-    const [pageLayout, setPageLayout] = useState<PageLayout>("single");
-    const [fitMode, setFitMode] = useState<FitMode>("original");
+	{ children, devProps, lang }) => {
+	const [readerLanguage, setReaderLanguage] = useState<Language>(lang);
+	const [mangaLanguage, setMangaLanguage] = useState<Language>(lang);
+	const [pageLayout, setPageLayout] = useState<PageLayout>("single");
+	const [fitMode, setFitMode] = useState<FitMode>("original");
 
-    const [manga, setManga] = useState(getManga(devProps));
-    const [page, setPage] = useState(0);
-    const [chapter, setChapter] = useState(0);
-    const [direction, setDirection] = useState<PageDirection>("ltr");
-    const [headerVisibility, setHeaderVisibility] =
-        useState<HeaderVisibility>("header-shown");
-    const [progressVisibility, setProgressVisibility] =
-        useState<ProgressVisibility>("progress-shown");
+	const [manga, setManga] = useState(getManga(devProps));
+	const [page, setPage] = useState(0);
+	const [chapter, setChapter] = useState(0);
+	const [direction, setDirection] = useState<PageDirection>("ltr");
+	const [headerVisibility, setHeaderVisibility] =
+		useState<HeaderVisibility>("header-shown");
+	const [progressVisibility, setProgressVisibility] =
+		useState<ProgressVisibility>("progress-shown");
 
-    const [readerTheme, setReaderTheme] = useState<ReaderTheme>(
-        readerThemes[0]
-    );
+	const [readerTheme, setReaderTheme] = useState<ReaderTheme>(readerThemes[0]);
 
-    const contextValue = useMemo(
-        () => ({
-            readerLanguage,
-            setReaderLanguage,
-            mangaLanguage,
-            setMangaLanguage,
-            page,
-            setPage,
-            chapter,
-            setChapter,
-            pageLayout,
-            setPageLayout,
-            fitMode,
-            setFitMode,
-            direction,
-            setDirection,
-            headerVisibility,
-            setHeaderVisibility,
-            progressVisibility,
-            setProgressVisibility,
-            readerTheme,
-            setReaderTheme,
-            manga,
-            setManga,
-        }),
-        [
-            readerLanguage,
-            mangaLanguage,
-            page,
-            chapter,
-            pageLayout,
-            fitMode,
-            direction,
-            headerVisibility,
-            progressVisibility,
-            readerTheme,
-            manga,
-        ]
-    );
+	const contextValue = useMemo(
+		() => ({
+			readerLanguage,
+			setReaderLanguage,
+			mangaLanguage,
+			setMangaLanguage,
+			page,
+			setPage,
+			chapter,
+			setChapter,
+			pageLayout,
+			setPageLayout,
+			fitMode,
+			setFitMode,
+			direction,
+			setDirection,
+			headerVisibility,
+			setHeaderVisibility,
+			progressVisibility,
+			setProgressVisibility,
+			readerTheme,
+			setReaderTheme,
+			manga,
+			setManga,
+		}),
+		[
+			readerLanguage,
+			mangaLanguage,
+			page,
+			chapter,
+			pageLayout,
+			fitMode,
+			direction,
+			headerVisibility,
+			progressVisibility,
+			readerTheme,
+			manga,
+		]
+	);
 
-    return (
-        <MangaContext.Provider value={contextValue}>
-            {children}
-        </MangaContext.Provider>
-    );
+	return (
+		<MangaContext.Provider value={contextValue}>
+			{children}
+		</MangaContext.Provider>
+	);
 };
 // eslint-enable
 
 // Custom hook to use the context
 export const useMangaContext = (): MangaContextProps => {
-    const context = useContext(MangaContext);
-    if (!context) {
-        throw new Error("useMangaContext must be used within an MangaProvider");
-    }
-    return context;
+	const context = useContext(MangaContext);
+	if (!context) {
+		throw new Error("useMangaContext must be used within an MangaProvider");
+	}
+	return context;
 };


### PR DESCRIPTION
Closes: #5. 

This PR contains two main changes:
- Add lazy loading to the manga images; we preload 3 pages ahead (or behind) the current page as well so reading should hopefully not be interrupted by loading as you click through or jump around pages.

  (A further extension is preloading chapter images ahead of time upon hitting the chapter boundary, I guess, but eh I suppose we can see how much that matters later)

- Switch to using URLs generated from `getImageUrl`; might not be the most optimized but this just precomputes a list of URL mappings and just uses it in place of the original URLs.

