### PR TITLE
feat: change menu and exit menu buttons

### DIFF
--- a/src/components/ui/project/irysmanga/ReaderHeader.tsx
+++ b/src/components/ui/project/irysmanga/ReaderHeader.tsx
@@ -31,60 +31,56 @@ function ReaderHeader({ setOpenSidebar }: Props) {
 	const currentChapter = mangaData.chapters[chapter];
 	return (
 		<>
-			{/* eslint-disable */}
-            <div
-                className={classNames(styles.fakeHeader, {
-                    [styles.fakeHeaderShown]:
-                        headerVisibility === "header-shown",
-                    [styles.fakeHeaderHidden]:
-                        headerVisibility === "header-hidden",
-                })}
-            ></div>
-            <div
-                className={classNames(styles.header, {
-                    [styles.headerShown]: headerVisibility === "header-shown",
-                    [styles.headerHidden]: headerVisibility === "header-hidden",
-                })}
-                ref={containerRef}
-            >
-                <div className="flex gap-2 items-center">
-                    <Link href={"/"}>
-                        <NavIcon></NavIcon>
-                    </Link>
-                    <div className={styles.infoBadge}>
-                        <strong className={""}>{mangaData.title}</strong>
-                        {/* <strong className={styles.infoBadgeContent}>
+			<div
+				className={classNames(styles.fakeHeader, {
+					[styles.fakeHeaderShown]:
+						headerVisibility === 'header-shown',
+					[styles.fakeHeaderHidden]:
+						headerVisibility === 'header-hidden',
+				})}
+			/>
+			<div
+				className={classNames(styles.header, {
+					[styles.headerShown]: headerVisibility === 'header-shown',
+					[styles.headerHidden]: headerVisibility === 'header-hidden',
+				})}
+				ref={containerRef}
+			>
+				<div className="flex items-center gap-2">
+					<Link href="/">
+						<NavIcon />
+					</Link>
+					<div className={styles.infoBadge}>
+						<strong className="">{mangaData.title}</strong>
+						{/* <strong className={styles.infoBadgeContent}>
                             {currentChapter.title}
                         </strong> */}
-                    </div>
-                </div>
-                <div className="flex gap-2 items-center">
-                    <div className={styles.infoBadge}>
-                        <span className={styles.infoBadgeTitle}>
-                            {tManga("chapter")}
-                        </span>
-                        <span className={styles.infoBadgeContent}>
-                            {chapter + 1} / {mangaData.chapterCount}
-                        </span>
-                    </div>
-                    <div className={styles.infoBadge}>
-                        <span className={styles.infoBadgeTitle}>
-                            {tManga("page")}
-                        </span>
-                        <span className={styles.infoBadgeContent}>
-                            {page + 1} / {currentChapter.pageCount}
-                        </span>
-                    </div>
-					{
-						<Bars3Icon
-							className="barIcon z-10"
-							onClick={() => setOpenSidebar((curr) => !curr)}
-							width={30}
-						/>
-					}
-                </div>
-            </div>
-            {/* eslint-enable */}
+					</div>
+				</div>
+				<div className="flex items-center gap-2">
+					<div className={styles.infoBadge}>
+						<span className={styles.infoBadgeTitle}>
+							{tManga('chapter')}
+						</span>
+						<span className={styles.infoBadgeContent}>
+							{`${chapter + 1} / ${mangaData.chapterCount}`}
+						</span>
+					</div>
+					<div className={styles.infoBadge}>
+						<span className={styles.infoBadgeTitle}>
+							{tManga('page')}
+						</span>
+						<span className={styles.infoBadgeContent}>
+							{`${page + 1} / ${currentChapter.pageCount}`}
+						</span>
+					</div>
+					<Bars3Icon
+						className="barIcon z-10"
+						onClick={() => setOpenSidebar((curr) => !curr)}
+						width={30}
+					/>
+				</div>
+			</div>
 		</>
 	);
 }

--- a/src/components/ui/project/irysmanga/ReaderHeader.tsx
+++ b/src/components/ui/project/irysmanga/ReaderHeader.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { useEffect, useRef } from 'react';
-import useTranslation from '@/lib/i18n/client';
 import classNames from 'classnames';
+import { Bars3Icon } from '@heroicons/react/24/solid';
 import { useMangaContext } from './context/MangaContext';
 import { getMangaDataOrThrow } from './utils/types';
 import './styles/styles.css';
@@ -17,7 +17,6 @@ function ReaderHeader({ setOpenSidebar }: Props) {
 	const {
 		page, chapter, manga, mangaLanguage, headerVisibility,
 	} = useMangaContext();
-	const { t } = useTranslation('reader');
 	const tManga = useDualTranslation(mangaLanguage);
 	const containerRef = useRef<HTMLDivElement>(null);
 
@@ -76,12 +75,13 @@ function ReaderHeader({ setOpenSidebar }: Props) {
                             {page + 1} / {currentChapter.pageCount}
                         </span>
                     </div>
-                    <button
-                        className={"btn btn-sm btn-neutral"}
-                        onClick={() => setOpenSidebar((prev) => !prev)}
-                    >
-                        {t("menu")}
-                    </button>
+					{
+						<Bars3Icon
+							className="barIcon z-10"
+							onClick={() => setOpenSidebar((curr) => !curr)}
+							width={30}
+						/>
+					}
                 </div>
             </div>
             {/* eslint-enable */}

--- a/src/components/ui/project/irysmanga/ReaderSidebar.tsx
+++ b/src/components/ui/project/irysmanga/ReaderSidebar.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { Bars3Icon } from '@heroicons/react/24/solid';
+import { XMarkIcon } from '@heroicons/react/24/solid';
 import {
 	BookOpenIcon,
 	DocumentIcon,
@@ -88,13 +88,6 @@ function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }: Props) {
 
 	return (
 		<>
-			{!openSidebar && headerVisibility === 'header-hidden' && (
-				<Bars3Icon
-					className="barIcon absolute right-0 z-10 mr-4 mt-2"
-					onClick={() => setOpenSidebar(true)}
-					width={30}
-				/>
-			)}
 			<div
 				className={classNames(styles.fakeSidebarContainer, {
 					[styles.fakeSidebarContainerOpen]: openSidebar,
@@ -108,18 +101,20 @@ function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }: Props) {
 				})}
 				ref={containerRef}
 			>
-				<Bars3Icon
-					onClick={() => setOpenSidebar(false)}
-					className="barIcon invisible absolute right-0 mr-2 md:visible"
-					width={30}
-				/>
 				{/* Manga info */}
 				<div className="400 flex flex-col gap-2">
-					<div className="flex items-center gap-1">
-						<BookOpenIcon width={30} />
-						<strong className=" whitespace-nowrap">
-							{mangaData.title}
-						</strong>
+					<div className="flex flex-row content-center items-center justify-between">
+						<div className="flex items-center gap-1">
+							<BookOpenIcon width={30} />
+							<strong className=" whitespace-nowrap">
+								{mangaData.title}
+							</strong>
+						</div>
+						<XMarkIcon
+							onClick={() => setOpenSidebar(false)}
+							className="size-9 rounded-full p-1 hover:bg-gray-200"
+							width={30}
+						/>
 					</div>
 					<div className="flex items-center gap-1">
 						<DocumentIcon width={30} />


### PR DESCRIPTION
Two small changes:

- Switch "menu" button to a hamburger menu.
- Switch the "exit menu" button in the menu to an X; IMO using a hamburger menu to mean "close the menu" is a bit confusing. I also made the X button show up on mobile as it might be confusing how to close the menu without it.

Question - should we hide the menu button if the menu is open? Not hard to do but just curious if we would want that behaviour. Only thing is that it going invisible/hidden might look a bit weird due to the chapter/page text right next to it, so that might need to also be looked at.

**Before**:

![image](https://github.com/Matriz88/hef-website/assets/25498386/a73866ae-d179-4259-a657-576ca450f562)

**After**:

![image](https://github.com/Matriz88/hef-website/assets/25498386/1c1f770a-b403-4eb6-9770-d0629abd41f1)

Feel free to close/give feedback if you prefer a different look.