### PR TITLE
fix: quick fix for id prop error in console

### DIFF
--- a/src/components/ui/project/irysmanga/SelectBox.tsx
+++ b/src/components/ui/project/irysmanga/SelectBox.tsx
@@ -1,6 +1,6 @@
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import Select from 'react-select';
-import { useState } from 'react';
+import { useState, useId } from 'react';
 import classNames from 'classnames';
 import { useMangaContext } from './context/MangaContext';
 import { handlePageNavigation } from './utils/helper';
@@ -89,6 +89,7 @@ function SelectBox({ value, label }: SelectBoxProps) {
                     menuIsOpen
                     classNamePrefix={"react-select"}
                     className="h-full grow"
+                    instanceId={useId()}
                     classNames={{
                         valueContainer: () => "w-full",
                         control: () =>


### PR DESCRIPTION
I noticed I was getting an error in the console about this; looked it up and apparently sticking a unique ID in the `instanceId` prop fixes it.

See: https://stackoverflow.com/questions/61290173/react-select-how-do-i-resolve-warning-prop-id-did-not-match