### PR TITLE
allow bypassing image proxy and switch to Next's `Image`

### DIFF
--- a/src/components/ui/project/irysmanga/IrysMangaSubmissionWrapper.tsx
+++ b/src/components/ui/project/irysmanga/IrysMangaSubmissionWrapper.tsx
@@ -22,8 +22,9 @@ const jura = Jura({
 });
 
 async function fetchOptimizedImageURLs({ project, lang }: IProps) {
-	// TODO: Change this to serve the actual manga.
 	const manga = getManga(project.devprops);
+	// Bypass if not set.
+	const bypassImgProxy = process.env.IMAGINARY_SECRET === '' && process.env.IMAGINARY_URL === '';
 	const { chapters } = manga.data[lang];
 
 	const optimizedImages = new Map<string, string[]>();
@@ -31,14 +32,20 @@ async function fetchOptimizedImageURLs({ project, lang }: IProps) {
 	chapters.forEach((chapter) => {
 		optimizedImages.set(
 			chapter.title,
-			chapter.pages.map((page) => getImageUrl(
-				{
-					src: page,
-					height: 1080,
-					quality: 90,
-					action: 'resize',
-				},
-			)),
+			chapter.pages.map((page) => {
+				if (bypassImgProxy) {
+					return page;
+				}
+
+				return getImageUrl(
+					{
+						src: page,
+						height: 1080,
+						quality: 90,
+						action: 'resize',
+					},
+				);
+			}),
 		);
 	});
 

--- a/src/components/ui/project/irysmanga/Reader.tsx
+++ b/src/components/ui/project/irysmanga/Reader.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import classNames from 'classnames';
+import Image from 'next/image';
 import React, { useEffect, useRef } from 'react';
 import { useMangaContext } from './context/MangaContext';
 import { handlePageNavigation } from './utils/helper';
@@ -41,7 +42,7 @@ function Reader({
 	const scriptedScroll = useRef(false);
 
 	// Sets the scrollbar to the correct position on page change
-	const setScollTopToPage = () => {
+	const setScrollTopToPage = () => {
 		if (containerRef.current) {
 			scriptedScroll.current = true;
 			const targetImg = pageRefs.current[page];
@@ -54,10 +55,10 @@ function Reader({
 	};
 	const handleScrollTop = () => {
 		if (pageLayout !== 'single' && !pageScrolled.current) {
-			setScollTopToPage();
+			setScrollTopToPage();
 		}
 		if (pageLayout === 'single') {
-			setScollTopToPage();
+			setScrollTopToPage();
 		}
 		pageScrolled.current = false;
 	};
@@ -86,7 +87,7 @@ function Reader({
 	 * for a better reading experience, but we don't want to load all the images at once
 	 * because that might be slow.
 	*/
-	const shouldPreload = (numPages: number, pg: number): ('eager' | 'lazy') => (Math.abs(numPages - pg) > 3 ? 'lazy' : 'eager');
+	const getPriority = (numPages: number, pg: number): boolean => Math.abs(numPages - pg) <= 3;
 
 	// Handle page turn on click
 	const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -155,7 +156,7 @@ function Reader({
 
 	// eslint-disable-next-line
 	useEffect(() => {
-		setScollTopToPage();
+		setScrollTopToPage();
 	}, [fitMode]);
 
 	let displayedPages: React.JSX.Element[] = [];
@@ -185,13 +186,17 @@ function Reader({
 		};
 
 		displayedPages = Array.from({ length: maxPageCount }, (_, i) => (
-			<img
+			<Image
 				key={i}
-				ref={(el) => { pageRefs.current[i] = el as HTMLImageElement; }}
 				src={currentPages[i]}
+				quality={100}
+				ref={(el) => { pageRefs.current[i] = el as HTMLImageElement; }}
 				className={getClassNames(i)}
+				priority={getPriority(i, page)}
 				alt={`Page ${i + 1}`}
-				loading={shouldPreload(i, page)}
+				width="0"
+				height={1080}
+				style={{ width: 'auto' }}
 			/>
 		));
 	}


### PR DESCRIPTION
Two changes:

1. If not set in the env, bypass the image proxy. This just makes for easier dev for now.
2. Switch to Next's `Image` as that seems to perform a bit better (at least for these unoptimized manga pages).