### PR TITLE
feat: disable language selection if there's only one chapter language

### DIFF
--- a/src/components/ui/project/irysmanga/ReaderSidebar.tsx
+++ b/src/components/ui/project/irysmanga/ReaderSidebar.tsx
@@ -17,6 +17,7 @@ import {
 	languages,
 	pageLayouts,
 	progressVisibilities,
+	ReaderSetting,
 	readerThemes,
 } from './utils/types';
 import SettingButton from './SettingButton';
@@ -86,6 +87,19 @@ function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }: Props) {
 		};
 	}, [setOpenSidebar, modalRef]);
 
+	const mangaLanguages: ReaderSetting[] = [];
+
+	languages.forEach((value) => {
+		// If no chapters don't allow it as a selectable target.
+		if (manga.data[value].chapterCount === 0) {
+			return;
+		}
+
+		if (manga.data[value].chapters[chapter] !== null) {
+			mangaLanguages.push(value);
+		}
+	});
+
 	return (
 		<>
 			<div
@@ -135,7 +149,8 @@ function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }: Props) {
 					<div className="flex w-full gap-1">
 						<SettingButton
 							value={mangaLanguage}
-							valueList={languages}
+							valueList={mangaLanguages}
+							disabled={mangaLanguages.length < 2}
 							// @ts-ignore
 							setValue={setMangaLanguage}
 							label="manga"

--- a/src/components/ui/project/irysmanga/SettingButton.tsx
+++ b/src/components/ui/project/irysmanga/SettingButton.tsx
@@ -24,6 +24,7 @@ interface Props {
 	valueList: ReadonlyArray<ReaderSetting>;
 	setValue: React.Dispatch<React.SetStateAction<ReaderSetting>>;
 	label?: string;
+	disabled?: boolean;
 }
 
 type SettingIcons = {
@@ -49,7 +50,7 @@ const settingIcons: SettingIcons = {
 };
 
 function SettingButton({
-	value, valueList, setValue, label,
+	value, valueList, setValue, label, disabled,
 }: Props) {
 	const { t } = useTranslation('reader');
 	return (
@@ -59,6 +60,7 @@ function SettingButton({
 				'justify-center': settingIcons[value] === null,
 			})}
 			type="button"
+			disabled={disabled}
 			onClick={() => setValue((prev) => getNextOption(prev, valueList))}
 		>
 			<div>


### PR DESCRIPTION
Admittedly this probably isn't needed once we get all the translations done, but something I noticed right now is that our code _really_ doesn't like it if you try to switch to JP since we only have English chapters, and errors everywhere. So I guess as a (temporary) safety measure, just prevent users from switching the language if there's no language to switch to in the first place.

Not sure if we would prefer to just disable the button or hide it altogether in this case; probably doesn't matter though as we likely won't have to worry about this when we actually release it. I hope.

Example of it disabled (reader language is left untouched as that doesn't depend on the languages in the manga data):

![image](https://github.com/Matriz88/hef-website/assets/25498386/1d24b79d-54d9-4e36-a497-4e59cb3d51d2)
