### PR TITLE
feat: add localstorage support for reader settings

### DIFF
--- a/src/components/ui/project/irysmanga/ReaderSidebar.tsx
+++ b/src/components/ui/project/irysmanga/ReaderSidebar.tsx
@@ -53,11 +53,12 @@ function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }: Props) {
 		setReaderTheme,
 	} = useMangaContext();
 	const { t, i18n } = useTranslation('reader');
+	const mangaData = getMangaDataOrThrow(manga, mangaLanguage);
+	const containerRef = useRef<HTMLDivElement>(null);
+
 	useEffect(() => {
 		i18n.changeLanguage(readerLanguage);
 	}, [readerLanguage, i18n]);
-	const mangaData = getMangaDataOrThrow(manga, mangaLanguage);
-	const containerRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		const width = containerRef.current?.getBoundingClientRect().width;
@@ -82,22 +83,18 @@ function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }: Props) {
 		// Set your threshold here (e.g., 768 for small screens)
 		document.addEventListener('mousedown', handleClickOutside);
 
-		return () => {
+		return (() => {
 			document.removeEventListener('mousedown', handleClickOutside);
-		};
+		});
 	}, [setOpenSidebar, modalRef]);
 
-	const mangaLanguages: ReaderSetting[] = [];
-
-	languages.forEach((value) => {
+	const mangaLanguages: ReaderSetting[] = languages.filter((value) => {
 		// If no chapters don't allow it as a selectable target.
 		if (manga.data[value].chapterCount === 0) {
-			return;
+			return false;
 		}
 
-		if (manga.data[value].chapters[chapter] !== null) {
-			mangaLanguages.push(value);
-		}
+		return (manga.data[value].chapters[chapter] !== null);
 	});
 
 	return (

--- a/src/components/ui/project/irysmanga/context/MangaContext.tsx
+++ b/src/components/ui/project/irysmanga/context/MangaContext.tsx
@@ -43,9 +43,7 @@ interface MangaContextProps {
 	setHeaderVisibility: React.Dispatch<React.SetStateAction<HeaderVisibility>>;
 
 	progressVisibility: ProgressVisibility;
-	setProgressVisibility: React.Dispatch<
-	React.SetStateAction<ProgressVisibility>
-	>;
+	setProgressVisibility: React.Dispatch<React.SetStateAction<ProgressVisibility>>;
 
 	readerTheme: ReaderTheme;
 	setReaderTheme: React.Dispatch<React.SetStateAction<ReaderTheme>>;
@@ -59,87 +57,83 @@ interface MangaContextProps {
 // Creating a context object
 const MangaContext = createContext<MangaContextProps | undefined>(undefined);
 
-/* eslint-disable */
+interface MangaProviderProps {
+	children: React.ReactNode;
+	devProps: { [key: string]: string };
+	lang: Language;
+	optimizedImages: Map<string, string[]>;
+}
+
 // Creating a provider component
-export const MangaProvider: React.FC<{
-    children: React.ReactNode;
-    devProps: { [key: string]: string };
-    lang: Language;
-    optimizedImages: Map<string, string[]>;
-}> = ({ children, devProps, lang, optimizedImages }) => {
-    const [readerLanguage, setReaderLanguage] = useState<Language>(lang);
-    const [mangaLanguage, setMangaLanguage] = useState<Language>(lang);
-    const [pageLayout, setPageLayout] = useState<PageLayout>("single");
-    const [fitMode, setFitMode] = useState<FitMode>("original");
+export function MangaProvider({
+	children, devProps, lang, optimizedImages,
+}: MangaProviderProps) {
+	const [readerLanguage, setReaderLanguage] = useState<Language>(lang);
+	const [mangaLanguage, setMangaLanguage] = useState<Language>(lang);
+	const [pageLayout, setPageLayout] = useState<PageLayout>('single');
+	const [fitMode, setFitMode] = useState<FitMode>('original');
+	const [manga, setManga] = useState(getManga(devProps));
+	const [page, setPage] = useState(0);
+	const [chapter, setChapter] = useState(0);
+	const [direction, setDirection] = useState<PageDirection>('ltr');
+	const [headerVisibility, setHeaderVisibility] = useState<HeaderVisibility>('header-shown');
+	const [progressVisibility, setProgressVisibility] = useState<ProgressVisibility>('progress-shown');
+	const [readerTheme, setReaderTheme] = useState<ReaderTheme>(readerThemes[0]);
 
-    const [manga, setManga] = useState(getManga(devProps));
-    const [page, setPage] = useState(0);
-    const [chapter, setChapter] = useState(0);
-    const [direction, setDirection] = useState<PageDirection>("ltr");
-    const [headerVisibility, setHeaderVisibility] =
-        useState<HeaderVisibility>("header-shown");
-    const [progressVisibility, setProgressVisibility] =
-        useState<ProgressVisibility>("progress-shown");
+	const contextValue = useMemo(
+		() => ({
+			readerLanguage,
+			setReaderLanguage,
+			mangaLanguage,
+			setMangaLanguage,
+			page,
+			setPage,
+			chapter,
+			setChapter,
+			pageLayout,
+			setPageLayout,
+			fitMode,
+			setFitMode,
+			direction,
+			setDirection,
+			headerVisibility,
+			setHeaderVisibility,
+			progressVisibility,
+			setProgressVisibility,
+			readerTheme,
+			setReaderTheme,
+			manga,
+			setManga,
+			optimizedImages,
+		}),
+		[
+			readerLanguage,
+			mangaLanguage,
+			page,
+			chapter,
+			pageLayout,
+			fitMode,
+			direction,
+			headerVisibility,
+			progressVisibility,
+			readerTheme,
+			manga,
+			optimizedImages,
+		],
+	);
 
-    const [readerTheme, setReaderTheme] = useState<ReaderTheme>(
-        readerThemes[0]
-    );
-
-    const contextValue = useMemo(
-        () => ({
-            readerLanguage,
-            setReaderLanguage,
-            mangaLanguage,
-            setMangaLanguage,
-            page,
-            setPage,
-            chapter,
-            setChapter,
-            pageLayout,
-            setPageLayout,
-            fitMode,
-            setFitMode,
-            direction,
-            setDirection,
-            headerVisibility,
-            setHeaderVisibility,
-            progressVisibility,
-            setProgressVisibility,
-            readerTheme,
-            setReaderTheme,
-            manga,
-            setManga,
-            optimizedImages,
-        }),
-        [
-            readerLanguage,
-            mangaLanguage,
-            page,
-            chapter,
-            pageLayout,
-            fitMode,
-            direction,
-            headerVisibility,
-            progressVisibility,
-            readerTheme,
-            manga,
-            optimizedImages,
-        ]
-    );
-
-    return (
-        <MangaContext.Provider value={contextValue}>
-            {children}
-        </MangaContext.Provider>
-    );
-};
-// eslint-enable
+	return (
+		<MangaContext.Provider value={contextValue}>
+			{children}
+		</MangaContext.Provider>
+	);
+}
 
 // Custom hook to use the context
 export const useMangaContext = (): MangaContextProps => {
-    const context = useContext(MangaContext);
-    if (!context) {
-        throw new Error("useMangaContext must be used within an MangaProvider");
-    }
-    return context;
+	const context = useContext(MangaContext);
+	if (!context) {
+		throw new Error('useMangaContext must be used within an MangaProvider');
+	}
+	return context;
 };

--- a/src/components/ui/project/irysmanga/utils/data-helper.ts
+++ b/src/components/ui/project/irysmanga/utils/data-helper.ts
@@ -54,13 +54,11 @@ function getDummyManga(): Manga {
 		const tmpPageCount = 9;
 		for (let j = 1; j <= tmpPageCount; ++j) {
 			enTmpPages.push(
-				`https://alt.hololive.tv/wp-content/uploads/2022/${tmp}/en${
-					i + 1
+				`https://alt.hololive.tv/wp-content/uploads/2022/${tmp}/en${i + 1
 				}_0${j}.jpg`,
 			);
 			jpTmpPages.push(
-				`https://alt.hololive.tv/wp-content/uploads/2022/${tmp}/jp${
-					i + 1
+				`https://alt.hololive.tv/wp-content/uploads/2022/${tmp}/jp${i + 1
 				}_0${j}.jpg`,
 			);
 		}
@@ -100,15 +98,14 @@ function objIsEmpty(obj: any): boolean {
 }
 
 export default function getManga(devProps: { [key: string]: string }): Manga {
-	if (
-		process.env.NODE_ENV === 'development'
-        && (!process.env.NEXT_PUBLIC_CMS_URL || objIsEmpty(devProps))
-	) {
+	if (process.env.NODE_ENV === 'development' && (!process.env.NEXT_PUBLIC_CMS_URL || objIsEmpty(devProps))) {
 		return getDummyManga();
 	}
+
 	const useDummy = true;
 	if (useDummy) {
 		return getDummyManga();
 	}
+
 	return getMangaFromDevProps(devProps);
 }

--- a/src/components/ui/project/irysmanga/utils/data-helper.ts
+++ b/src/components/ui/project/irysmanga/utils/data-helper.ts
@@ -54,12 +54,10 @@ function getDummyManga(): Manga {
 		const tmpPageCount = 9;
 		for (let j = 1; j <= tmpPageCount; ++j) {
 			enTmpPages.push(
-				`https://alt.hololive.tv/wp-content/uploads/2022/${tmp}/en${i + 1
-				}_0${j}.jpg`,
+				`https://alt.hololive.tv/wp-content/uploads/2022/${tmp}/en${i + 1}_0${j}.jpg`,
 			);
 			jpTmpPages.push(
-				`https://alt.hololive.tv/wp-content/uploads/2022/${tmp}/jp${i + 1
-				}_0${j}.jpg`,
+				`https://alt.hololive.tv/wp-content/uploads/2022/${tmp}/jp${i + 1}_0${j}.jpg`,
 			);
 		}
 		const enTitle = i === 2 ? 'Super duper long title' : 'Short title';

--- a/src/components/ui/project/irysmanga/utils/types.ts
+++ b/src/components/ui/project/irysmanga/utils/types.ts
@@ -31,7 +31,6 @@ export type Manga = {
 };
 
 // Reader settings types
-
 export const fitModes = ['height', 'width', 'original'] as const;
 export type FitMode = (typeof fitModes)[number];
 
@@ -47,10 +46,7 @@ export type PageDirection = (typeof directions)[number];
 export const headerVisibilities = ['header-hidden', 'header-shown'] as const;
 export type HeaderVisibility = (typeof headerVisibilities)[number];
 
-export const progressVisibilities = [
-	'progress-hidden',
-	'progress-shown',
-] as const;
+export const progressVisibilities = ['progress-hidden', 'progress-shown'] as const;
 export type ProgressVisibility = (typeof progressVisibilities)[number];
 
 export const readerThemes = ['light', 'dark'] as const;


### PR DESCRIPTION
Closes: #19 

All the sidebar settings now are stored and loaded from `localStorage`.

One thing I did notice while testing it (but I've seen it before this PR) is that there's a brief flash + loading page shows when refreshing, and with this PR, it'll briefly be unable to read from `localStorage` for that initial first render before fixing itself. I _think_ that's fine from looking around, should hopefully not be an issue in prod builds?