### PR TITLE
fix: use optimized images for all languages

### DIFF
--- a/src/components/ui/project/irysmanga/IrysMangaDataWrapper.tsx
+++ b/src/components/ui/project/irysmanga/IrysMangaDataWrapper.tsx
@@ -21,31 +21,34 @@ const jura = Jura({
 	subsets: ['latin'],
 });
 
-async function fetchOptimizedImageURLs({ project, lang }: IProps) {
+async function fetchOptimizedImageURLs({ project }: IProps) {
 	const manga = getManga(project.devprops);
 
 	// Bypass if not set.
 	const bypassImgProxy = !process.env.IMAGINARY_URL;
-	const { chapters } = manga.data[lang];
 
 	const optimizedImages = new Map<string, string[]>();
 
-	chapters.forEach((chapter) => {
-		optimizedImages.set(
-			chapter.title,
-			chapter.pages.map((page) => {
-				if (bypassImgProxy) {
-					return page;
-				}
+	Object.entries(manga.data).forEach((mangaDataPair) => {
+		const currentData = mangaDataPair[1];
 
-				return getImageUrl({
-					src: page,
-					height: 1080,
-					quality: 90,
-					action: 'resize',
-				});
-			}),
-		);
+		currentData.chapters.forEach((chapter) => {
+			optimizedImages.set(
+				chapter.id,
+				chapter.pages.map((page) => {
+					if (bypassImgProxy) {
+						return page;
+					}
+
+					return getImageUrl({
+						src: page,
+						height: 1080,
+						quality: 90,
+						action: 'resize',
+					});
+				}),
+			);
+		});
 	});
 
 	return optimizedImages;

--- a/src/components/ui/project/irysmanga/Reader.tsx
+++ b/src/components/ui/project/irysmanga/Reader.tsx
@@ -170,7 +170,7 @@ export default function Reader({
 		const currentChapter = mangaData.chapters[chapter];
 		const maxPageCount = currentChapter.pageCount;
 		// Use optimized pages if we have them, otherwise fall back to unoptimized I guess.
-		const currentPages = optimizedImages.get(currentChapter.title) ?? currentChapter.pages;
+		const currentPages = optimizedImages.get(currentChapter.id) ?? currentChapter.pages;
 
 		const getClassNamesContainer = (i: number) => {
 			const blockStyle = (

--- a/src/components/ui/project/irysmanga/utils/data-helper.ts
+++ b/src/components/ui/project/irysmanga/utils/data-helper.ts
@@ -65,11 +65,13 @@ function getDummyManga(): Manga {
 		const jpTitle = i === 2 ? 'めちゃくちゃ長いタイトル' : '短いタイトル';
 
 		tmpMangaData[0].chapters.push({
+			id: 'en-ch-1',
 			title: enTitle,
 			pageCount: tmpPageCount,
 			pages: enTmpPages,
 		});
 		tmpMangaData[1].chapters.push({
+			id: 'jp-ch-1',
 			title: jpTitle,
 			pageCount: tmpPageCount,
 			pages: jpTmpPages,

--- a/src/components/ui/project/irysmanga/utils/types.ts
+++ b/src/components/ui/project/irysmanga/utils/types.ts
@@ -1,4 +1,5 @@
 export type Chapter = {
+	id: string;
 	title: string;
 	pageCount: number;
 	pages: string[];


### PR DESCRIPTION
Fixed a bug where only the active language had optimized image urls. This change also adds an id for chapters to make it a bit easier to refer to them programmatically.

Fixes https://github.com/Matriz88/hef-website/issues/20