### PR TITLE
Consolidate multiple contributor fields into a single field

### DIFF
--- a/public/locales/en/reader.json
+++ b/public/locales/en/reader.json
@@ -30,7 +30,9 @@
         "authors": "Authors",
         "artists": "Artists",
         "translators": "Translators",
-        "programmers": "Programmers"
+        "programmers": "Programmers",
+        "organizers": "Organizers",
+        "lead-artists":"Lead Artists"
     },
     "modal-story": {
         "greeting": "Story",

--- a/public/locales/jp/reader.json
+++ b/public/locales/jp/reader.json
@@ -30,7 +30,9 @@
         "authors": "著者",
         "artists": "アーティスト",
         "translators": "翻訳者",
-        "programmers": "プログラマー"
+        "programmers": "プログラマー",
+        "organizers": "主催者",
+        "lead-artists":"リードアーティスト"
     },
     "modal-story": {
         "greeting": "ストーリー",

--- a/src/components/ui/project/irysmanga/modal-components/CreditBlock.tsx
+++ b/src/components/ui/project/irysmanga/modal-components/CreditBlock.tsx
@@ -6,6 +6,45 @@ interface IProps {
 	contributors: Contributor[];
 }
 
+interface RCProps {
+	label: string;
+	contributor: Contributor
+}
+
+function RenderedContributor({ label, contributor }: RCProps) {
+	if (contributor.socials.length === 0) {
+		return (
+			<li>
+				{contributor.name}
+			</li>
+		);
+	}
+
+	return (
+		<li>
+			{contributor.name}
+			{' '}
+			-
+			{' '}
+			{contributor.socials.map((social) => (
+				<span
+					key={`span-${label}-${contributor.name}-${social.platform}`}
+				>
+					<a
+						href={social.link}
+						className="link"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{social.platform}
+					</a>
+					{' '}
+				</span>
+			))}
+		</li>
+	);
+}
+
 export default function CreditBlock({ label, contributors }: IProps) {
 	const { t } = useTranslation('reader', 'modal-general');
 
@@ -17,27 +56,11 @@ export default function CreditBlock({ label, contributors }: IProps) {
 			</h3>
 			<ul className="ml-4 list-inside list-disc">
 				{contributors.map((contributor) => (
-					<li key={`li-${label}-${contributor.name}`}>
-						{contributor.name}
-						{' '}
-						-
-						{' '}
-						{contributor.socials.map((social) => (
-							<span
-								key={`span-${label}-${contributor.name}-${social.platform}`}
-							>
-								<a
-									href={social.link}
-									className="link"
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									{social.platform}
-								</a>
-								{' '}
-							</span>
-						))}
-					</li>
+					<RenderedContributor
+						key={`rc-${label}-${contributor.name}`}
+						label={label}
+						contributor={contributor}
+					/>
 				))}
 			</ul>
 		</div>

--- a/src/components/ui/project/irysmanga/modal-components/ModalTabGeneral.tsx
+++ b/src/components/ui/project/irysmanga/modal-components/ModalTabGeneral.tsx
@@ -15,13 +15,30 @@ export default function ModalTabGeneral() {
 				{t('credits')}
 			</h2>
 			<div className="grid w-full lg:grid-cols-2 lg:grid-rows-2">
-				<CreditBlock label="authors" contributors={manga.authors} />
-				<CreditBlock label="artists" contributors={manga.artists} />
+				<CreditBlock
+					label="organizers"
+					contributors={manga.contributors.filter((e) => e.role === 'organizer')}
+				/>
+				<CreditBlock
+					label="authors"
+					contributors={manga.contributors.filter((e) => e.role === 'writer')}
+				/>
+				<CreditBlock
+					label="lead-artists"
+					contributors={manga.contributors.filter((e) => e.role === 'lead-artist')}
+				/>
+				<CreditBlock
+					label="artists"
+					contributors={manga.contributors.filter((e) => e.role === 'artist')}
+				/>
 				<CreditBlock
 					label="translators"
-					contributors={manga.translators}
+					contributors={manga.contributors.filter((e) => e.role === 'translator')}
 				/>
-				<CreditBlock label="programmers" contributors={manga.devs} />
+				<CreditBlock
+					label="programmers"
+					contributors={manga.contributors.filter((e) => e.role === 'developer')}
+				/>
 			</div>
 		</ModalTabContent>
 	);

--- a/src/components/ui/project/irysmanga/utils/data-helper.ts
+++ b/src/components/ui/project/irysmanga/utils/data-helper.ts
@@ -1,4 +1,4 @@
-import { Contributor, Manga, MangaData } from './types';
+import { Manga, MangaData } from './types';
 
 function getMangaFromDevProps(devProps: { [key: string]: string }): Manga {
 	if (!devProps.mangaData) {
@@ -6,27 +6,6 @@ function getMangaFromDevProps(devProps: { [key: string]: string }): Manga {
 	}
 
 	return JSON.parse(devProps.mangaData);
-}
-
-function getDummyContributors(role: string): Contributor[] {
-	return Array.from({ length: 5 }, (_, i) => ({
-		// eslint-disable-next-line no-plusplus
-		name: `${role} name ${i}`,
-		socials: [
-			{
-				platform: 'Twitter',
-				link: '',
-			},
-			{
-				platform: 'Pixiv',
-				link: '',
-			},
-			{
-				platform: 'Github',
-				link: '',
-			},
-		],
-	}));
 }
 
 function getDummyManga(): Manga {
@@ -79,10 +58,23 @@ function getDummyManga(): Manga {
 	return {
 		id: 'test-manga',
 		publishedDate: '2024-01-16',
-		authors: getDummyContributors('Author'),
-		artists: getDummyContributors('Artist'),
-		translators: getDummyContributors('Translator'),
-		devs: getDummyContributors('Developer'),
+		contributors: [
+			{
+				name: 'Test1',
+				role: 'artist',
+				socials: [],
+			},
+			{
+				name: 'Test2',
+				role: 'writer',
+				socials: [
+					{
+						platform: 'twitter',
+						link: '',
+					},
+				],
+			},
+		],
 		data: {
 			en: tmpMangaData[0],
 			jp: tmpMangaData[1],

--- a/src/components/ui/project/irysmanga/utils/data-helper.ts
+++ b/src/components/ui/project/irysmanga/utils/data-helper.ts
@@ -61,7 +61,7 @@ function getDummyManga(): Manga {
 		contributors: [
 			{
 				name: 'Test1',
-				role: 'artist',
+				role: 'organizer',
 				socials: [],
 			},
 			{
@@ -70,6 +70,82 @@ function getDummyManga(): Manga {
 				socials: [
 					{
 						platform: 'twitter',
+						link: '',
+					},
+				],
+			},
+			{
+				name: 'Test3',
+				role: 'lead-artist',
+				socials: [
+					{
+						platform: 'pixiv',
+						link: '',
+					},
+					{
+						platform: 'twitter',
+						link: '',
+					},
+				],
+			},
+			{
+				name: 'Test4a',
+				role: 'artist',
+				socials: [
+					{
+						platform: 'pixiv',
+						link: '',
+					},
+					{
+						platform: 'twitter',
+						link: '',
+					},
+				],
+			},
+			{
+				name: 'Test4b',
+				role: 'artist',
+				socials: [
+					{
+						platform: 'pixiv',
+						link: '',
+					},
+					{
+						platform: 'twitter',
+						link: '',
+					},
+				],
+			},
+			{
+				name: 'Test4c',
+				role: 'artist',
+				socials: [
+					{
+						platform: 'pixiv',
+						link: '',
+					},
+					{
+						platform: 'twitter',
+						link: '',
+					},
+				],
+			},
+			{
+				name: 'Test5',
+				role: 'translator',
+				socials: [
+					{
+						platform: 'twitter',
+						link: '',
+					},
+				],
+			},
+			{
+				name: 'Test6',
+				role: 'developer',
+				socials: [
+					{
+						platform: 'github',
 						link: '',
 					},
 				],

--- a/src/components/ui/project/irysmanga/utils/types.ts
+++ b/src/components/ui/project/irysmanga/utils/types.ts
@@ -14,6 +14,7 @@ export type MangaData = {
 
 export type Contributor = {
 	name: string;
+	role: 'organizer' | 'writer' | 'lead-artist' | 'artist' | 'translator' | 'developer';
 	socials: {
 		platform: string;
 		link: string;
@@ -23,10 +24,7 @@ export type Contributor = {
 export type Manga = {
 	id: string;
 	publishedDate: string; // Publish date must be in ISO8601
-	authors: Contributor[];
-	artists: Contributor[];
-	translators: Contributor[];
-	devs: Contributor[];
+	contributors: Contributor[];
 	data: { readonly [lang: string]: MangaData }; // Maps ISO language codes to correct data.
 };
 


### PR DESCRIPTION
Consolidates the `authors, artists, translators, devs` fields into one single `contributors` field and adds additional contributor roles as needed. There is also a tweak to the rendering of `CreditsBlock` to handle an edge case where a contributor has no defined socials.

Closes https://github.com/Matriz88/hef-website/issues/26