### PR TITLE
Update progress bar and X button colours; fix dark mode in .css

### DIFF
--- a/src/components/ui/project/irysmanga/ReaderSidebar.tsx
+++ b/src/components/ui/project/irysmanga/ReaderSidebar.tsx
@@ -124,7 +124,7 @@ export default function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }:
 						</div>
 						<XMarkIcon
 							onClick={() => setOpenSidebar(false)}
-							className="size-9 rounded-full p-1"
+							className="size-9 rounded-full bg-black/0 p-1 hover:bg-black/[.08] dark:bg-white/0 dark:hover:bg-white/10"
 							width={30}
 						/>
 					</div>

--- a/src/components/ui/project/irysmanga/ReaderSidebar.tsx
+++ b/src/components/ui/project/irysmanga/ReaderSidebar.tsx
@@ -74,8 +74,8 @@ export default function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }:
 			}
 			if (
 				containerRef.current
-                && !containerRef.current.contains(event.target as Node)
-                && !modalRef.current?.open
+				&& !containerRef.current.contains(event.target as Node)
+				&& !modalRef.current?.open
 			) {
 				setOpenSidebar(false);
 			}
@@ -124,7 +124,7 @@ export default function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }:
 						</div>
 						<XMarkIcon
 							onClick={() => setOpenSidebar(false)}
-							className="size-9 rounded-full p-1 hover:bg-gray-200"
+							className="size-9 rounded-full p-1"
 							width={30}
 						/>
 					</div>
@@ -200,7 +200,7 @@ export default function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }:
 						valueList={readerThemes}
 						onClick={() => setTheme(resolvedTheme === 'light' ? 'dark' : 'light')}
 						// @ts-ignore
-						setValue={() => {}}
+						setValue={() => { }}
 						label="theme"
 					/>
 					<SettingButton

--- a/src/components/ui/project/irysmanga/styles/ProgressBar.module.css
+++ b/src/components/ui/project/irysmanga/styles/ProgressBar.module.css
@@ -1,66 +1,72 @@
 .progressOuterContainer {
-    @apply sticky bg-transparent z-10 w-full h-[60px] flex items-end transition-all;
+  @apply sticky z-10 w-full h-[60px] flex items-end transition-all opacity-0;
 }
 
 .progressOuterContainerOpen {
-    @apply opacity-100;
+  @apply opacity-100;
 }
 
 .progressOuterContainerClose {
-    @apply opacity-0;
+  @apply opacity-0;
 }
 
 .progressInnerContainer {
-    @apply w-[100%] flex transition-all;
+  @apply w-[100%] flex transition-all;
 }
 
 .progressInnerContainerOpen {
-    @apply h-[20px] opacity-100;
+  @apply h-[20px] opacity-100;
 }
 
 .progressInnerContainerClose {
-    @apply h-[5px] opacity-50;
+  @apply h-[5px] opacity-50;
 }
 
 .numberLabelContainer {
-    @apply h-full min-w-4 px-2 py-1 flex justify-center items-center bg-base-300 overflow-hidden;
+  @apply h-full min-w-4 px-2 py-1 flex justify-center items-center overflow-hidden bg-skin-background dark:bg-skin-background-dark text-skin-text dark:text-skin-text-dark;
 }
 
 .numberLabelContainerFadeLeft {
-    background: linear-gradient(to left, oklch(var(--nc)) 8%, transparent);
+  @apply bg-gradient-to-l from-[#a6adbb] from-[8%] to-transparent;
 }
 
 .numberLabelContainerFadeRight {
-    background: linear-gradient(to right, oklch(var(--nc)) 8%, transparent);
+  @apply bg-gradient-to-r from-[#a6adbb] from-[8%] to-transparent;
 }
 
 .numberLabel {
-    @apply transition-all w-[1.5rem] text-center;
+  @apply transition-all w-[1.5rem] text-center;
 }
 
 .numberLabelOpen {
-    @apply opacity-100;
+  @apply opacity-100;
 }
 
 .numberLabelClose {
-    @apply opacity-0;
+  @apply opacity-0;
 }
 
 .progressBarContainer {
-    @apply h-full grow bg-neutral-content transition-all;
+  @apply h-full grow transition-all;
+  background-color: #a6adbb;
 }
 
 .progressSectionsContainer {
-    @apply flex justify-between w-full h-full;
+  @apply flex justify-between w-full h-full;
 }
 
 .progressSectionTooltip {
-    @apply z-10 flex h-full cursor-pointer grow border-x tooltip tooltip-top tooltip-open hover:bg-neutral bg-transparent transition-all duration-100 ease-in-out;
+  @apply z-10 flex h-full cursor-pointer grow border-x tooltip tooltip-top tooltip-open transition-all duration-100 ease-in-out;
+}
+
+.progressSectionTooltip:hover {
+  background-color: #5c6774;
 }
 
 .progressSectionTooltipActive {
-    @apply opacity-100 bg-neutral;
+  background-color: #2a323c;
 }
+
 .progressSectionTooltipSelected {
-    @apply opacity-100 bg-neutral;
+  background-color: #2a323c;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -41,7 +41,7 @@ module.exports = {
         "./src/pages/**/*.{js,ts,jsx,tsx}",
         "./src/components/**/*.{js,ts,jsx,tsx}",
     ],
-    darkMode: "class",
+    darkMode: ['class', "[class~='dark']"], // See https://github.com/tailwindlabs/tailwindcss/discussions/2917
     theme: {
         extend: {
             fontFamily: {


### PR DESCRIPTION
Few things in this PR:

1. `dark:` wasn't working in `.css` files, I've applied a fix from the linked tailwind issue.
2. I made it so the progress bar numbers are visible by making them match the theme colours.
3. Also fixed the menu X button's background having the wrong effect in dark mode.