### PR TITLE
Fix a few issues around page scrolling on long mode

### DIFF
--- a/src/components/ui/project/irysmanga/IrysManga.tsx
+++ b/src/components/ui/project/irysmanga/IrysManga.tsx
@@ -11,9 +11,6 @@ export default function IrysManga() {
 	const readerContainerRef = useRef(null);
 	const modalRef = useRef(null);
 
-	// Set a counter to detect click counts, necessary for closing the sidebar
-	// when clicked outside without triggering the page turning
-
 	return (
 		<div className="relative flex h-screen w-screen min-w-[310px] flex-row-reverse overflow-hidden bg-skin-background text-skin-text dark:bg-skin-background-dark dark:text-skin-text-dark">
 			<ReaderSidebar

--- a/src/components/ui/project/irysmanga/KeyPressHandler.tsx
+++ b/src/components/ui/project/irysmanga/KeyPressHandler.tsx
@@ -88,14 +88,14 @@ export default function KeyPressHandler({ setOpenSidebar, readerContainerRef, mo
 				}
 			}
 			if (event.key === ',') {
-				if (pageLayout === 'ltr') {
+				if (pageLayout === 'ltr' || pageLayout === 'long') {
 					handleChapterNavigation(setChapter, setPage, chapter - 1, mangaLanguage, manga);
 				} else {
 					handleChapterNavigation(setChapter, setPage, chapter + 1, mangaLanguage, manga);
 				}
 			}
 			if (event.key === '.') {
-				if (pageLayout === 'ltr') {
+				if (pageLayout === 'ltr' || pageLayout === 'long') {
 					handleChapterNavigation(setChapter, setPage, chapter + 1, mangaLanguage, manga);
 				} else {
 					handleChapterNavigation(setChapter, setPage, chapter - 1, mangaLanguage, manga);
@@ -160,7 +160,7 @@ export default function KeyPressHandler({ setOpenSidebar, readerContainerRef, mo
 				scrollDirectionRef.current = scrollDirection;
 				scrollIntervalRef.current = setInterval(() => {
 					// eslint-disable-next-line
-                    readerContainerRef.current!.scrollTop += scrollDirectionRef.current! * 10; // Adjust scrolling speed as needed
+					readerContainerRef.current!.scrollTop += scrollDirectionRef.current! * 10; // Adjust scrolling speed as needed
 				}, 10); // Adjust interval as needed for smoother scrolling
 			}
 		};

--- a/src/components/ui/project/irysmanga/KeyPressHandler.tsx
+++ b/src/components/ui/project/irysmanga/KeyPressHandler.tsx
@@ -45,7 +45,6 @@ export default function KeyPressHandler({ setOpenSidebar, readerContainerRef, mo
 				if (pageLayout === 'ltr' || pageLayout === 'long') {
 					handlePageNavigation(
 						page - 1,
-						pageLayout,
 						setPage,
 						setChapter,
 						chapter,
@@ -55,7 +54,6 @@ export default function KeyPressHandler({ setOpenSidebar, readerContainerRef, mo
 				} else {
 					handlePageNavigation(
 						page + 1,
-						pageLayout,
 						setPage,
 						setChapter,
 						chapter,
@@ -68,7 +66,6 @@ export default function KeyPressHandler({ setOpenSidebar, readerContainerRef, mo
 				if (pageLayout === 'ltr' || pageLayout === 'long') {
 					handlePageNavigation(
 						page + 1,
-						pageLayout,
 						setPage,
 						setChapter,
 						chapter,
@@ -78,7 +75,6 @@ export default function KeyPressHandler({ setOpenSidebar, readerContainerRef, mo
 				} else {
 					handlePageNavigation(
 						page - 1,
-						pageLayout,
 						setPage,
 						setChapter,
 						chapter,
@@ -151,6 +147,7 @@ export default function KeyPressHandler({ setOpenSidebar, readerContainerRef, mo
 		setOpenSidebar,
 		setPageLayout,
 		setProgressVisibility,
+		setTheme,
 		resolvedTheme,
 		modalRef,
 	]);

--- a/src/components/ui/project/irysmanga/Reader.tsx
+++ b/src/components/ui/project/irysmanga/Reader.tsx
@@ -1,8 +1,11 @@
 'use client';
 
+import lod from 'lodash';
 import classNames from 'classnames';
 import NextImage from 'next/image';
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+	useEffect, useMemo, useRef, useState,
+} from 'react';
 import { useMangaContext } from './context/MangaContext';
 import { handlePageNavigation } from './utils/helper';
 import ProgressBar from './ProgressBar';
@@ -36,6 +39,10 @@ export default function Reader({
 
 	const mangaData = getMangaDataOrThrow(manga, mangaLanguage);
 	const pageRefs = useRef<HTMLImageElement[]>([]);
+
+	const isScrollCausedByUserScroll = useRef<boolean>(false);
+	const isHandleScrollLocked = useRef<boolean>(false); // A check to "lock" the handleScroll event.
+
 	const [loading, setLoading] = useState<boolean[]>(
 		Array(mangaData.chapters[chapter].pageCount).fill(true),
 	);
@@ -48,13 +55,23 @@ export default function Reader({
 	});
 
 	/**
+	 * A function to automatically set the "is user currently the one scrolling" state to false.
+	 */
+	const handleEndScroll = useMemo(() => lod.debounce(() => {
+		isScrollCausedByUserScroll.current = false;
+	}, 100), []);
+
+	/**
 	 * Update the page counter when the user scrolls.
 	 * It chooses the page that has the closest middle point to the container's middle point
 	 */
 	const handleScroll = () => {
-		if (!containerRef.current) {
+		if (!containerRef.current || (pageLayout === 'long' && isHandleScrollLocked.current)) {
 			return;
 		}
+
+		isScrollCausedByUserScroll.current = true;
+
 		const containerRect = containerRef.current.getBoundingClientRect();
 		const containerMiddleY = (containerRect.top + containerRect.bottom) / 2;
 		let minDistY = Infinity;
@@ -71,6 +88,8 @@ export default function Reader({
 		if (chosenPage !== -1) {
 			setPage(chosenPage);
 		}
+
+		handleEndScroll();
 	};
 
 	/**
@@ -97,7 +116,6 @@ export default function Reader({
 		const threshold = width / 2;
 		if (position < threshold) {
 			const diff = (pageLayout === 'ltr' || pageLayout === 'long') ? -1 : 1;
-
 			handlePageNavigation(
 				page + diff,
 				setPage,
@@ -108,7 +126,6 @@ export default function Reader({
 			);
 		} else {
 			const diff = (pageLayout === 'ltr' || pageLayout === 'long') ? 1 : -1;
-
 			handlePageNavigation(
 				page + diff,
 				setPage,
@@ -121,22 +138,51 @@ export default function Reader({
 	};
 
 	useEffect(() => {
+		if (pageLayout === 'long' && isScrollCausedByUserScroll.current) {
+			return;
+		}
+
 		if (containerRef.current) {
 			const targetImg = pageRefs.current[page];
 			if (targetImg) {
-				// eslint-disable-next-line no-param-reassign
-				containerRef.current.scrollTop = targetImg.offsetTop - containerRef.current.offsetTop;
+				if (pageLayout === 'long') {
+					// If:
+					// - We are in long mode
+					// - The page hasn't fully loaded yet
+					// Then keep the scroll lock UNTIL the page (and the page after) is loaded and
+					// we've scrolled to it!
+					//
+					// TODO: Maybe change it so it waits until pages load first? But eh, too lazy.
+
+					const currentPageLoading = loading[page];
+					const nextPageLoading = (page + 1) < mangaData.chapters[chapter].pages.length
+						? loading[page + 1]
+						: false;
+
+					if (currentPageLoading || nextPageLoading) {
+						isHandleScrollLocked.current = true;
+					}
+
+					// eslint-disable-next-line no-param-reassign
+					containerRef.current.scrollTop = targetImg.offsetTop - containerRef.current.offsetTop;
+
+					if (!currentPageLoading && !nextPageLoading) {
+						isHandleScrollLocked.current = false;
+					}
+				} else {
+					// eslint-disable-next-line no-param-reassign
+					containerRef.current.scrollTop = targetImg.offsetTop - containerRef.current.offsetTop;
+				}
 			}
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [page, chapter, pageLayout, fitMode, containerRef]);
+	}, [page, chapter, pageLayout, loading, fitMode, containerRef, mangaData.chapters]);
 
 	let displayedPages: React.JSX.Element[] = [];
 	if (mangaData.chapters[chapter]) {
 		const currentChapter = mangaData.chapters[chapter];
 		const maxPageCount = currentChapter.pageCount;
 		// Use optimized pages if we have them, otherwise fall back to unoptimized I guess.
-		const currentPages = optimizedImages.get(currentChapter.id) ?? currentChapter.pages;
+		const pageSources = optimizedImages.get(currentChapter.id) ?? currentChapter.pages;
 
 		/**
 		 * Returns class names for the page _container_.
@@ -234,7 +280,7 @@ export default function Reader({
 				>
 					{loading[i] && <LoadingIcon />}
 					<NextImage
-						src={currentPages[i]}
+						src={pageSources[i]}
 						className={getClassNamesPageImage()}
 						quality={100}
 						priority={getPriority(i, page)}

--- a/src/components/ui/project/irysmanga/Reader.tsx
+++ b/src/components/ui/project/irysmanga/Reader.tsx
@@ -95,10 +95,8 @@ export default function Reader({
 
 		const position = clientX - left;
 		const threshold = width / 2;
-		let currentPage = page;
 		if (position < threshold) {
 			const diff = (pageLayout === 'ltr' || pageLayout === 'long') ? -1 : 1;
-			currentPage += diff;
 
 			handlePageNavigation(
 				page + diff,
@@ -110,7 +108,6 @@ export default function Reader({
 			);
 		} else {
 			const diff = (pageLayout === 'ltr' || pageLayout === 'long') ? 1 : -1;
-			currentPage += diff;
 
 			handlePageNavigation(
 				page + diff,
@@ -120,14 +117,6 @@ export default function Reader({
 				mangaLanguage,
 				manga,
 			);
-		}
-
-		if (pageLayout === 'long' && containerRef.current) {
-			const targetImg = pageRefs.current[currentPage];
-			if (targetImg) {
-				// eslint-disable-next-line no-param-reassign
-				containerRef.current.scrollTop = targetImg.offsetTop - containerRef.current.offsetTop;
-			}
 		}
 	};
 
@@ -140,7 +129,7 @@ export default function Reader({
 			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [chapter, pageLayout, fitMode, containerRef]);
+	}, [page, chapter, pageLayout, fitMode, containerRef]);
 
 	let displayedPages: React.JSX.Element[] = [];
 	if (mangaData.chapters[chapter]) {

--- a/src/components/ui/project/irysmanga/Reader.tsx
+++ b/src/components/ui/project/irysmanga/Reader.tsx
@@ -40,7 +40,7 @@ export default function Reader({
 		Array(mangaData.chapters[chapter].pageCount).fill(true),
 	);
 	const [imageSizes, setImageSizes] = useState(
-		Array(mangaData.chapters[chapter].pageCount).fill({ width: 0, height: 0 }),
+		Array(mangaData.chapters[chapter].pageCount).fill({ width: 0, height: 1080 }),
 	);
 	const [containerDimensions, setContainerDimensions] = useState({
 		width: 0,
@@ -260,9 +260,8 @@ export default function Reader({
 								.map((curr, index) => (index === i ? false : curr)));
 
 							const originalImage = ele.currentTarget;
-							setImageSizes((currentImageSizes) => currentImageSizes.map((curr, idx) =>
-								// eslint-disable-next-line max-len, implicit-arrow-linebreak
-								(idx === i ? { width: originalImage.naturalWidth, height: originalImage.naturalHeight } : curr)));
+							// eslint-disable-next-line max-len, implicit-arrow-linebreak
+							setImageSizes((currentImageSizes) => currentImageSizes.map((curr, idx) => (idx === i ? { width: originalImage.naturalWidth, height: originalImage.naturalHeight } : curr)));
 						}}
 					/>
 				</div>

--- a/src/components/ui/project/irysmanga/SelectBox.tsx
+++ b/src/components/ui/project/irysmanga/SelectBox.tsx
@@ -14,7 +14,7 @@ interface SelectBoxProps {
 
 function SelectBox({ value, label }: SelectBoxProps) {
 	const {
-		mangaLanguage, setPage, chapter, setChapter, manga, pageLayout,
+		mangaLanguage, setPage, chapter, setChapter, manga,
 	} = useMangaContext();
 	const mangaData = getMangaDataOrThrow(manga, mangaLanguage);
 	const { t } = useTranslation('reader');
@@ -26,7 +26,6 @@ function SelectBox({ value, label }: SelectBoxProps) {
 		if (label === 'page') {
 			handlePageNavigation(
 				selectedValue,
-				pageLayout,
 				setPage,
 				setChapter,
 				chapter,
@@ -89,11 +88,11 @@ function SelectBox({ value, label }: SelectBoxProps) {
 						menuList: () => 'scroll-smooth',
 						option: ({ isFocused, isSelected }) => classNames('hover:cursor-pointer p-2 font-sm rounded truncate', {
 							'bg-skin-header dark:bg-skin-header-dark text-skin-header-foreground dark:text-skin-header-foreground-dark':
-                                    isSelected,
+								isSelected,
 							'hover:bg-[color-mix(in_srgb,rgb(var(--color-secondary))_90%,black)] dark:hover:bg-[color-mix(in_srgb,rgb(var(--color-secondary-dark))_90%,black)]':
-                                    isFocused && !isSelected,
+								isFocused && !isSelected,
 							'text-skin-secondary-foreground  dark:text-skin-secondary-foreground-dark':
-                                    !isSelected && !isFocused,
+								!isSelected && !isFocused,
 						}),
 					}}
 				/>

--- a/src/components/ui/project/irysmanga/context/MangaContext.tsx
+++ b/src/components/ui/project/irysmanga/context/MangaContext.tsx
@@ -70,8 +70,8 @@ export function MangaProvider({
 	const isBrowserWindowReady = () => typeof window !== 'undefined';
 
 	/**
-     * Grab settings from localStorage if set.
-     */
+	 * Grab settings from localStorage if set.
+	 */
 	function getSettings<T>(key: string, def: T): T {
 		// If for some reason local storage isn't available yet, just return the default values.
 		if (!isBrowserWindowReady()) {
@@ -115,22 +115,23 @@ export function MangaProvider({
 	const [manga, setManga] = useState<Manga>(getManga(devProps));
 
 	// Fetch the page/chapter from the URL, else use the default value of 0.
-	function getPageAndChapterFromHash() : number[] {
+	function getPageAndChapterFromHash(): number[] {
 		if (isBrowserWindowReady()) {
 			const { hash } = window.location;
 			const parts = hash.split('/');
 
 			const result = [0, 0];
 			if (parts.length === 2) {
-				const chapter = parseInt(parts[0].substring(1), 10);
-				const page = parseInt(parts[1], 10);
+				const chapter = parseInt(parts[0].substring(1), 10) - 1;
+				const page = parseInt(parts[1], 10) - 1;
 
 				result[0] = Number.isNaN(chapter) ? result[0] : chapter;
 				result[1] = Number.isNaN(page) ? result[1] : page;
 
 				const mangaData = getMangaDataOrThrow(manga, mangaLanguage);
-				result[0] = result[0] >= mangaData.chapterCount ? 0 : result[0];
-				result[1] = result[1] >= mangaData.chapters[result[0]].pageCount ? 0 : result[1];
+				result[0] = result[0] >= mangaData.chapterCount || result[0] < 0 ? 0 : result[0];
+				const invalidPage = result[1] >= mangaData.chapters[result[0]].pageCount || result[1] < 0;
+				result[1] = invalidPage ? 0 : result[1];
 			}
 
 			return result;
@@ -176,7 +177,7 @@ export function MangaProvider({
 	// Wrapped in useEffect to ensure that it only runs when page or chapter is updated.
 	// Also helps silence some spurious errors.
 	useEffect(() => {
-		router.replace(`#${chapter}/${page}`);
+		router.replace(`#${chapter + 1}/${page + 1}`);
 	}, [page, chapter, router]);
 
 	const contextValue = useMemo(

--- a/src/components/ui/project/irysmanga/utils/helper.ts
+++ b/src/components/ui/project/irysmanga/utils/helper.ts
@@ -1,8 +1,7 @@
-import { Manga, PageLayout, getMangaDataOrThrow } from './types';
+import { Manga, getMangaDataOrThrow } from './types';
 
 export const handlePageNavigation = (
 	selectedPage: number,
-	_pageLayout: PageLayout,
 	setPage: React.Dispatch<React.SetStateAction<number>>,
 	setChapter: React.Dispatch<React.SetStateAction<number>>,
 	chapter: number,
@@ -18,15 +17,15 @@ export const handlePageNavigation = (
 		setChapter((prev) => prev - 1);
 	} else if (
 		selectedPage >= currentChapter.pageCount
-        && chapter >= 0
-        && chapter < mangaData.chapterCount - 1
+		&& chapter >= 0
+		&& chapter < mangaData.chapterCount - 1
 	) {
 		// Case: Change to the next chapter if the page index is >= currentChapter.pageCount
 		setPage(0);
 		setChapter((prev) => prev + 1);
 	} else if (
 		selectedPage >= 0
-        && selectedPage <= currentChapter.pageCount - 1
+		&& selectedPage <= currentChapter.pageCount - 1
 	) {
 		// Case: Change to the selected page
 		setPage(selectedPage);


### PR DESCRIPTION
Fixes the following issues:

1. Move the URL pages to be 1-based so it matches with what the user expects.
2. Closes: #37 - we do the following to fix it:
    - When the user is scrolling, disable the auto-scroll-to-top action.
    - When the user stops scrolling for ~100ms, we automatically disable this lock.
3. Fixes scrolling to the page in the URL. We do this by disabling the `handleScroll` function until all pages are loaded (on long page mode) and we fully scroll to it; I _think_ this is fine?