### PR TITLE
fix: fix progress bar fadeout not being the right colour

### DIFF
--- a/src/components/ui/project/irysmanga/styles/ProgressBar.module.css
+++ b/src/components/ui/project/irysmanga/styles/ProgressBar.module.css
@@ -27,11 +27,11 @@
 }
 
 .numberLabelContainerFadeLeft {
-    @apply bg-gradient-to-l from-[#a6adbb] from-[8%] to-transparent;
+    @apply bg-transparent dark:bg-transparent bg-gradient-to-l from-[color-mix(in_srgb,rgb(var(--color-secondary))_60%,white)] dark:from-[color-mix(in_srgb,rgb(var(--color-secondary-dark))_60%,white)] from-[8%] to-transparent
 }
 
 .numberLabelContainerFadeRight {
-    @apply bg-gradient-to-r from-[#a6adbb] from-[8%] to-transparent;
+    @apply bg-transparent dark:bg-transparent bg-gradient-to-r from-[color-mix(in_srgb,rgb(var(--color-secondary))_60%,white)] dark:from-[color-mix(in_srgb,rgb(var(--color-secondary-dark))_60%,white)] from-[8%] to-transparent
 }
 
 .numberLabel {
@@ -59,7 +59,7 @@
 }
 
 .progressSectionTooltip:hover {
-    @apply bg-[color-mix(in_srgb,rgb(var(--color-header))_50%,white)];
+    @apply bg-[color-mix(in_srgb,rgb(var(--color-header))_60%,white)];
 }
 
 .progressSectionTooltipActive {


### PR DESCRIPTION
Before:

![image](https://github.com/Matriz88/hef-website/assets/25498386/0197f429-8e9f-4ce7-af2f-5029d975abcc)
![image](https://github.com/Matriz88/hef-website/assets/25498386/cf75d16e-f0f4-412f-9eaa-a868f3089e11)


After:

![image](https://github.com/Matriz88/hef-website/assets/25498386/bc3d9088-f3a8-4bf1-a5c5-4769302a46db)
![image](https://github.com/Matriz88/hef-website/assets/25498386/595e3f56-a3f8-4f12-a4ec-be4e7ffcdc0e)
