### PR TITLE
A few small fixes/tweaks

### DIFF
--- a/src/components/ui/project/irysmanga/IrysManga.tsx
+++ b/src/components/ui/project/irysmanga/IrysManga.tsx
@@ -21,7 +21,7 @@ export default function IrysManga() {
 	const modalRef = useRef(null);
 
 	return (
-		<div className="relative flex h-screen w-screen min-w-[310px] flex-row-reverse overflow-hidden bg-skin-background text-skin-text dark:bg-skin-background-dark dark:text-skin-text-dark">
+		<div className="relative flex h-dvh w-screen min-w-[310px] flex-row-reverse overflow-hidden bg-skin-background text-skin-text dark:bg-skin-background-dark dark:text-skin-text-dark">
 			<ReaderSidebar
 				openSidebar={openSidebar}
 				setOpenSidebar={setOpenSidebar}

--- a/src/components/ui/project/irysmanga/IrysManga.tsx
+++ b/src/components/ui/project/irysmanga/IrysManga.tsx
@@ -6,7 +6,16 @@ import ReaderSidebar from './ReaderSidebar';
 import KeyPressHandler from './KeyPressHandler';
 
 export default function IrysManga() {
-	const [openSidebar, setOpenSidebar] = useState(true);
+	const [openSidebar, setOpenSidebar] = useState((() => {
+		if (window) {
+			const MOBILE_PAGE_WIDTH = 768;
+			const { innerWidth } = window;
+
+			return innerWidth >= MOBILE_PAGE_WIDTH;
+		}
+
+		return true;
+	})());
 
 	const readerContainerRef = useRef(null);
 	const modalRef = useRef(null);

--- a/src/components/ui/project/irysmanga/Reader.tsx
+++ b/src/components/ui/project/irysmanga/Reader.tsx
@@ -47,7 +47,7 @@ export default function Reader({
 		Array(mangaData.chapters[chapter].pageCount).fill(true),
 	);
 	const [imageSizes, setImageSizes] = useState(
-		Array(mangaData.chapters[chapter].pageCount).fill({ width: 0, height: 1080 }),
+		Array(mangaData.chapters[chapter].pageCount).fill({ width: 0, height: 0 }),
 	);
 	const [containerDimensions, setContainerDimensions] = useState({
 		width: 0,

--- a/src/components/ui/project/irysmanga/Reader.tsx
+++ b/src/components/ui/project/irysmanga/Reader.tsx
@@ -104,8 +104,9 @@ export default function Reader({
 	const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
 		const { clientX, target } = event;
 		const { left, width } = (target as HTMLElement).getBoundingClientRect();
+		const MOBILE_PAGE_WIDTH = 768;
 
-		if (window.innerWidth <= 768) {
+		if (window.innerWidth <= MOBILE_PAGE_WIDTH) {
 			if (openSidebar) {
 				setOpenSidebar(false);
 				return;

--- a/src/components/ui/project/irysmanga/ReaderHeader.tsx
+++ b/src/components/ui/project/irysmanga/ReaderHeader.tsx
@@ -43,7 +43,7 @@ export default function ReaderHeader({ openSidebar, setOpenSidebar }: Props) {
 				ref={containerRef}
 			>
 				<div className="flex items-center gap-2">
-					<Link href="/">
+					<Link href="/" tabIndex={headerVisibility === 'header-shown' ? 0 : -1}>
 						<Icon />
 					</Link>
 					<div className={styles.infoBadge}>
@@ -63,17 +63,23 @@ export default function ReaderHeader({ openSidebar, setOpenSidebar }: Props) {
 							{`${page + 1} / ${currentChapter.pageCount}`}
 						</span>
 					</div>
-					<Bars3Icon
-						className={classNames(
-							'transition-all cursor-pointer hover:opacity-100 z-10',
-							{
-								'opacity-0': openSidebar,
-								'opacity-60': !openSidebar,
-							},
-						)}
+					<button
+						type="button"
+						aria-label="Open the sidebar"
 						onClick={() => setOpenSidebar((curr) => !curr)}
-						width={openSidebar ? 0 : 30}
-					/>
+						disabled={openSidebar || headerVisibility === 'header-hidden'}
+					>
+						<Bars3Icon
+							className={classNames(
+								'transition-all cursor-pointer hover:opacity-100 z-10',
+								{
+									'opacity-0': openSidebar,
+									'opacity-60': !openSidebar,
+								},
+							)}
+							width={openSidebar ? 0 : 30}
+						/>
+					</button>
 				</div>
 			</div>
 		</>

--- a/src/components/ui/project/irysmanga/ReaderSidebar.tsx
+++ b/src/components/ui/project/irysmanga/ReaderSidebar.tsx
@@ -86,17 +86,18 @@ export default function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }:
 	return (
 		<>
 			{/* This is a hamburger menu if both the header and the menu is closed. */}
-			{/* eslint-disable-next-line max-len */}
-			{/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-			<div
+			<button
+				type="button"
+				aria-label="Open the sidebar"
 				className={classNames(
-					'z-10 absolute right-4 top-4 w-[60px] h-[60px] cursor-pointer flex justify-end items-start',
+					'z-10 absolute right-4 top-4 cursor-pointer flex justify-end items-start',
 					{
 						hidden: openSidebar || headerVisibility === 'header-shown',
 						block: !(openSidebar || headerVisibility === 'header-shown'),
 					},
 				)}
 				onClick={() => setOpenSidebar((curr) => !curr)}
+				disabled={openSidebar}
 			>
 				<Bars3Icon
 					className={classNames(
@@ -104,7 +105,7 @@ export default function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }:
 					)}
 					width={30}
 				/>
-			</div>
+			</button>
 
 			<div
 				className={classNames(styles.fakeSidebarContainer, {
@@ -127,11 +128,16 @@ export default function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }:
 							<BookOpenIcon width={30} />
 							<strong className="whitespace-nowrap">{mangaData.title}</strong>
 						</div>
-						<XMarkIcon
+						<button
+							type="button"
+							aria-label="Close the sidebar"
 							onClick={() => setOpenSidebar(false)}
-							className={styles.xButton}
-							width={30}
-						/>
+						>
+							<XMarkIcon
+								className={styles.xButton}
+								width={30}
+							/>
+						</button>
 					</div>
 					<div className="flex items-center gap-1">
 						<DocumentIcon width={30} />
@@ -205,7 +211,7 @@ export default function ReaderSidebar({ openSidebar, setOpenSidebar, modalRef }:
 						valueList={readerThemes}
 						onClick={() => setTheme(resolvedTheme === 'light' ? 'dark' : 'light')}
 						// @ts-ignore
-						setValue={() => {}}
+						setValue={() => { }}
 						label="theme"
 					/>
 				</div>

--- a/src/components/ui/project/irysmanga/SelectBox.tsx
+++ b/src/components/ui/project/irysmanga/SelectBox.tsx
@@ -64,7 +64,7 @@ function SelectBox({ value, label }: SelectBoxProps) {
 
 			{/* eslint-disable-next-line max-len */}
 			{/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-			<div className="h-full grow" onClick={() => setOpen(!open)}>
+			<button className="h-full grow text-left" onClick={() => setOpen(!open)} type="button" aria-label={`Select ${label}`}>
 				<Select
 					value={options[value]}
 					onChange={(selectedOption) => handleSelectValue(parseInt(selectedOption!.value, 10))}
@@ -76,6 +76,7 @@ function SelectBox({ value, label }: SelectBoxProps) {
 					classNamePrefix="react-select"
 					className="h-full grow"
 					instanceId={useId()}
+					tabIndex={-1}
 					classNames={{
 						valueContainer: () => 'w-full',
 						control: () => 'rounded-md w-full h-full px-2 hover:cursor-pointer bg-skin-secondary dark:bg-skin-secondary-dark text-skin-secondary-foreground transition-all hover:bg-[color-mix(in_srgb,rgb(var(--color-secondary))_90%,black)] dark:text-skin-secondary-foreground-dark dark:hover:bg-[color-mix(in_srgb,rgb(var(--color-secondary-dark))_90%,black)]',
@@ -98,7 +99,7 @@ function SelectBox({ value, label }: SelectBoxProps) {
 						}),
 					}}
 				/>
-			</div>
+			</button>
 
 			<button
 				className={nextButtonClasses}

--- a/src/components/ui/project/irysmanga/SelectBox.tsx
+++ b/src/components/ui/project/irysmanga/SelectBox.tsx
@@ -57,7 +57,13 @@ function SelectBox({ value, label }: SelectBoxProps) {
 				aria-label="left-page"
 				type="button"
 				onClick={() => handleSelectValue(value - 1)}
-				disabled={value === 0}
+				disabled={(() => {
+					if (label === 'page') {
+						return value === 0 && chapter === 0;
+					}
+
+					return (value === 0);
+				})()}
 			>
 				<ChevronLeftIcon className="size-5" />
 			</button>
@@ -106,7 +112,15 @@ function SelectBox({ value, label }: SelectBoxProps) {
 				aria-label="right-page"
 				type="button"
 				onClick={() => handleSelectValue(value + 1)}
-				disabled={value === maxValue - 1}
+				disabled={(() => {
+					if (label === 'page') {
+						return (
+							((value + 1) === maxValue) && (chapter + 1) === mangaData.chapterCount
+						);
+					}
+
+					return ((value + 1) === maxValue);
+				})()}
 			>
 				<ChevronRightIcon width={20} />
 			</button>

--- a/src/components/ui/project/irysmanga/context/MangaContext.tsx
+++ b/src/components/ui/project/irysmanga/context/MangaContext.tsx
@@ -103,7 +103,7 @@ export function MangaProvider({
 		getSettings('localMangaLanguage', lang),
 	);
 	const [pageLayout, setPageLayout] = useState<PageLayout>(getSettings('localPageLayout', 'ltr'));
-	const [fitMode, setFitMode] = useState<FitMode>(getSettings('localFitMode', 'original'));
+	const [fitMode, setFitMode] = useState<FitMode>(getSettings('localFitMode', 'fit-both'));
 	const [headerVisibility, setHeaderVisibility] = useState<HeaderVisibility>(
 		getSettings('localHeaderVisibility', 'header-shown'),
 	);

--- a/src/components/ui/project/irysmanga/modal-components/ReaderModal.tsx
+++ b/src/components/ui/project/irysmanga/modal-components/ReaderModal.tsx
@@ -20,7 +20,9 @@ export default function ReaderModal({ modalRef }: IProps) {
 	const { t } = useTranslation('reader');
 	const options = ['General', 'Story', 'Reader'];
 	return (
-		<dialog id="info_modal" className="modal bg-gradient-to-r" ref={modalRef}>
+		// The "invisible" stops tabbing going to invisible elements while the modal is hidden.
+		// It seems to work fine when it's shown.
+		<dialog id="info_modal" className="modal invisible bg-gradient-to-r" ref={modalRef}>
 			<div className="modal-box flex h-[90%] min-w-[50%] max-w-[70%] flex-col justify-between overflow-hidden">
 				<div className="flex max-h-[87%] grow flex-col">
 					<div className="tabs-lifted flex self-center">

--- a/src/components/ui/project/irysmanga/styles/Sidebar.module.css
+++ b/src/components/ui/project/irysmanga/styles/Sidebar.module.css
@@ -7,7 +7,7 @@
 }
 
 .sidebarContainerHidden {
-    @apply translate-x-full opacity-0;
+    @apply translate-x-full opacity-0 invisible;
 }
 
 /* Need this to be hidden on small viewports to remove it from the flow */


### PR DESCRIPTION
This PR contains a few fixes pertaining to #42:

1. Hide the sidebar by default on mobile devices: I found this kinda disorientating if it opened by default on a phone as half your screen is blocked when you open the page and clear the modal.
2. Change the default fit mode to fit-both: similar to above, on phones, it's weird if it's on "original" as then the page might be way bigger than your phone screen which is disorientating.
3. The progress bar was hidden due to the variable height of phone browsers from the toolbar. This was because we set the reader height to be `100vh`; this changes it to be `100dvh` which avoids the problem.
4. Fix a warning about the height/width being set for the images. This seems to be because I set the height of the `Image` component before it was loaded while fixing #33. I reverted that specific part and it doesn't seem like it breaks anything...? Might want to test it though.
5. Fix `tab` accessibility being super broken for a lot of stuff. I try to give a shit about this stuff; the following things were changed:
  - The modal was causing a lot of "invisible" tab selections when it was hidden. Turns out that you can just set the visibility to be hidden and it fixes it, and it all still works when the modal is actually shown.
  - A bunch of buttons weren't actually buttons, I just made everything that should be a button.
  - A few elements were "eating" the tabs (e.g. the link when hiding a header), this fixes that.
6. Make page select buttons more intuitive in regards to when they get disabled. They now only disable themselves if they are on the first page _and_ we are on the first chapter, or if we are on the last page _and_ on the last chapter. Otherwise, clicking prev/next will just change the chapter as expected.